### PR TITLE
feat(label): Handle label descriptions (if they exist)

### DIFF
--- a/lib/label.js
+++ b/lib/label.js
@@ -7,27 +7,30 @@ const request = require('request-promise');
 const assert = require('assert');
 
 class Label {
+
   constructor(owner, repo, token) {
     this.owner = owner;
     this.repo = repo;
     this.token = token;
-    this.rp = request.defaults({ 
+    this.rp = request.defaults({
       baseUrl: `${GH_HOST}/repos/${this.owner}/${this.repo}`,
       headers: {
+        // Opt-in into the preview version in order to be able to work with label descriptions
+        // See <https://github.com/octokit/octokit.rb/issues/1001#issuecomment-379505671>
+        Accept: 'application/vnd.github.symmetra-preview+json',
         'user-agent': 'gh-label',
       },
       json: true
     });
- 
   }
 
   getAll() {
     const options = {
-      uri: `/labels`,
+      uri: '/labels',
     };
     if (this.token) {
       options.headers = {
-        Authorization: `token ${this.token}` //needed if private repo
+        Authorization: `token ${this.token}` // Needed if private repo
       };
     }
 
@@ -35,7 +38,14 @@ class Label {
       .then(res => {
         debug('original lables: %j', res);
         return res.map(label => {
-          return { name: label.name, color: label.color };
+          const simplifiedLabel = {
+            color: label.color,
+            name: label.name,
+          };
+          if (label.description) { // Only use actual description values (not "null")
+            simplifiedLabel.description = label.description;
+          }
+          return simplifiedLabel;
         });
       });
   }
@@ -56,7 +66,7 @@ class Label {
         }
         return;
       });
-  } 
+  }
 
   removeAll() {
     const createRemovePromise = (labelName) => {
@@ -65,7 +75,7 @@ class Label {
 
     return this.getAll()
       .then(labels => {
-        return labels.map(l => createRemovePromise(l.name)); 
+        return labels.map(l => createRemovePromise(l.name));
       })
       .then(removePromises => {
         return Promise.all(removePromises);
@@ -83,7 +93,7 @@ class Label {
     assert(label.name);
     assert(label.color);
     const options = {
-      uri: `/labels`,
+      uri: '/labels',
       method: 'POST',
       headers: {
         Authorization: `token ${this.token}`

--- a/test/label.test.js
+++ b/test/label.test.js
@@ -18,22 +18,31 @@ describe('Label class', () => {
       .reply(200, [
             {
               url: 'http://xxx.xxx',
-              name: 'foo',
-              color: '523526' 
+              color: '523526',
+              description: 'This is foo.',
+              name: 'foo'
             },
             {
               url: 'http://xxx.xxx',
-              name: 'bar',
-              color: 'f23266' 
+              color: 'f23266',
+              description: null,
+              name: 'bar'
             }
           ]);
     const lbl = new Label('lorem', 'ipsum', 'dolor');
     return lbl.getAll()
       .then((labels) => {
-        expect(labels).to.be.an('array');
-        expect(labels.length).to.be.equal(2);
-        expect(labels[0].name).to.be.equal('foo');
-        expect(labels[1].name).to.be.equal('bar');
+        expect(labels).to.deep.equal([
+          {
+            color: '523526',
+            description: 'This is foo.',
+            name: 'foo'
+          },
+          {
+            color: 'f23266',
+            name: 'bar'
+          }
+        ]);
       });
   });
 
@@ -60,8 +69,15 @@ describe('Label class', () => {
     //mock getAll
     lbl.getAll = () => {
       return Promise.resolve([
-          { name: 'ipsum', color: '252562' },
-          { name: 'lorem', color: '15f567' },
+          {
+            color: '252562',
+            description: 'This is ipsum',
+            name: 'ipsum'
+          },
+          {
+            color: '15f567',
+            name: 'lorem'
+          },
       ]);
     };
     lbl.remove = (labelName) => {
@@ -84,6 +100,23 @@ describe('Label class', () => {
       });
     const lbl = new Label('lorem', 'ipsum', 'dolor');
     lbl.create({ name: 'foobar', color: '235266' });
+  });
+
+  it('create should succeed, with label description', () => {
+    nock('https://api.github.com')
+      .post('/repos/lorem/ipsum/labels', {
+        color: '235266',
+        description: 'foobar description',
+        name: 'foobar'
+      })
+      .reply(201, {
+        color: '235266',
+        description: 'foobar description',
+        url: 'https://api.github.com/repos/lorem/ipsum/labels/foobar',
+        name: 'foobar'
+      });
+    const lbl = new Label('lorem', 'ipsum', 'dolor');
+    lbl.create({ color: '235266', description: 'foobar description', name: 'foobar' });
   });
 
   it('createAll should succeed', () => {


### PR DESCRIPTION
This PR enables the usage of label descriptions. In particular:

- When retrieving (/ exporting) all labels, a `description` attribute will exist if the label desciption is defined
- When creating all labels, `description` attributes will be recognized and defined properly

Closes #4.